### PR TITLE
PCU support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 *.iml
+.DS_Store

--- a/astra/astra.gen.go
+++ b/astra/astra.gen.go
@@ -8101,7 +8101,7 @@ type PcuCreateResponse struct {
 	JSON201      *[]PCUGroup
 	JSON400      *BadRequest
 	JSON403      *Forbidden
-	JSON5XX      *ServerError
+	JSON500      *ServerError
 }
 
 // Status returns HTTPResponse.Status
@@ -8127,7 +8127,7 @@ type PcuUpdateResponse struct {
 	JSON400      *BadRequest
 	JSON403      *Forbidden
 	JSON404      *NotFound
-	JSON5XX      *ServerError
+	JSON500      *ServerError
 }
 
 // Status returns HTTPResponse.Status
@@ -8153,7 +8153,7 @@ type PcuGetResponse struct {
 	JSON400      *BadRequest
 	JSON403      *Forbidden
 	JSON404      *NotFound
-	JSON5XX      *ServerError
+	JSON500      *ServerError
 }
 
 // Status returns HTTPResponse.Status
@@ -8177,7 +8177,7 @@ type PcuAssociationTransferResponse struct {
 	HTTPResponse *http.Response
 	JSON400      *BadRequest
 	JSON403      *Forbidden
-	JSON5XX      *ServerError
+	JSON500      *ServerError
 }
 
 // Status returns HTTPResponse.Status
@@ -8203,7 +8203,7 @@ type PcuAssociationGetResponse struct {
 	JSON400      *BadRequest
 	JSON403      *Forbidden
 	JSON404      *NotFound
-	JSON5XX      *ServerError
+	JSON500      *ServerError
 }
 
 // Status returns HTTPResponse.Status
@@ -8228,7 +8228,7 @@ type PcuAssociationDeleteResponse struct {
 	JSON400      *BadRequest
 	JSON403      *Forbidden
 	JSON404      *NotFound
-	JSON5XX      *ServerError
+	JSON500      *ServerError
 }
 
 // Status returns HTTPResponse.Status
@@ -8253,7 +8253,7 @@ type PcuAssociationCreateResponse struct {
 	JSON400      *BadRequest
 	JSON403      *Forbidden
 	JSON404      *NotFound
-	JSON5XX      *ServerError
+	JSON500      *ServerError
 }
 
 // Status returns HTTPResponse.Status
@@ -8277,7 +8277,7 @@ type PcuGroupParkResponse struct {
 	HTTPResponse *http.Response
 	JSON400      *BadRequest
 	JSON403      *Forbidden
-	JSON5XX      *ServerError
+	JSON500      *ServerError
 }
 
 // Status returns HTTPResponse.Status
@@ -8301,7 +8301,7 @@ type PcuGroupUnparkResponse struct {
 	HTTPResponse *http.Response
 	JSON400      *BadRequest
 	JSON403      *Forbidden
-	JSON5XX      *ServerError
+	JSON500      *ServerError
 }
 
 // Status returns HTTPResponse.Status
@@ -8326,7 +8326,7 @@ type PcuDeleteResponse struct {
 	JSON400      *BadRequest
 	JSON403      *Forbidden
 	JSON404      *NotFound
-	JSON5XX      *ServerError
+	JSON500      *ServerError
 }
 
 // Status returns HTTPResponse.Status
@@ -12046,12 +12046,12 @@ func ParsePcuCreateResponse(rsp *http.Response) (*PcuCreateResponse, error) {
 		}
 		response.JSON403 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest ServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON5XX = &dest
+		response.JSON500 = &dest
 
 	}
 
@@ -12100,12 +12100,12 @@ func ParsePcuUpdateResponse(rsp *http.Response) (*PcuUpdateResponse, error) {
 		}
 		response.JSON404 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest ServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON5XX = &dest
+		response.JSON500 = &dest
 
 	}
 
@@ -12154,12 +12154,12 @@ func ParsePcuGetResponse(rsp *http.Response) (*PcuGetResponse, error) {
 		}
 		response.JSON404 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest ServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON5XX = &dest
+		response.JSON500 = &dest
 
 	}
 
@@ -12194,12 +12194,12 @@ func ParsePcuAssociationTransferResponse(rsp *http.Response) (*PcuAssociationTra
 		}
 		response.JSON403 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest ServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON5XX = &dest
+		response.JSON500 = &dest
 
 	}
 
@@ -12248,12 +12248,12 @@ func ParsePcuAssociationGetResponse(rsp *http.Response) (*PcuAssociationGetRespo
 		}
 		response.JSON404 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest ServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON5XX = &dest
+		response.JSON500 = &dest
 
 	}
 
@@ -12295,12 +12295,12 @@ func ParsePcuAssociationDeleteResponse(rsp *http.Response) (*PcuAssociationDelet
 		}
 		response.JSON404 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest ServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON5XX = &dest
+		response.JSON500 = &dest
 
 	}
 
@@ -12342,12 +12342,12 @@ func ParsePcuAssociationCreateResponse(rsp *http.Response) (*PcuAssociationCreat
 		}
 		response.JSON404 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest ServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON5XX = &dest
+		response.JSON500 = &dest
 
 	}
 
@@ -12382,12 +12382,12 @@ func ParsePcuGroupParkResponse(rsp *http.Response) (*PcuGroupParkResponse, error
 		}
 		response.JSON403 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest ServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON5XX = &dest
+		response.JSON500 = &dest
 
 	}
 
@@ -12422,12 +12422,12 @@ func ParsePcuGroupUnparkResponse(rsp *http.Response) (*PcuGroupUnparkResponse, e
 		}
 		response.JSON403 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest ServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON5XX = &dest
+		response.JSON500 = &dest
 
 	}
 
@@ -12469,12 +12469,12 @@ func ParsePcuDeleteResponse(rsp *http.Response) (*PcuDeleteResponse, error) {
 		}
 		response.JSON404 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest ServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON5XX = &dest
+		response.JSON500 = &dest
 
 	}
 

--- a/astra/astra.gen.go
+++ b/astra/astra.gen.go
@@ -81,12 +81,6 @@ const (
 	Sa   DatacenterRegionZone = "sa"
 )
 
-// Defines values for InstanceType.
-const (
-	PcuInstanceTypeStandard         InstanceType = "standard"
-	PcuInstanceTypeStorageOptimized InstanceType = "storageOptimized"
-)
-
 // Defines values for PCUAssociationStatus.
 const (
 	PCUAssociationStatusAccepted PCUAssociationStatus = "Accepted"
@@ -805,9 +799,6 @@ type GoogleVPC struct {
 	VpcNetworkName string `json:"vpcNetworkName"`
 }
 
-// InstanceType Instance type for PCU groups
-type InstanceType string
-
 // KafkaBootstrapServer Kafka bootstrap server
 type KafkaBootstrapServer = string
 
@@ -974,7 +965,7 @@ type PCUGroup struct {
 	Description *string `json:"description,omitempty"`
 
 	// InstanceType Instance type for PCU groups
-	InstanceType *InstanceType `json:"instanceType,omitempty"`
+	InstanceType *string `json:"instanceType,omitempty"`
 
 	// Max Maximum shared hourly PCUs in the PCU group
 	Max *int `json:"max,omitempty"`
@@ -1019,7 +1010,7 @@ type PCUGroupCreateRequest struct {
 	Description *string `json:"description,omitempty"`
 
 	// InstanceType Instance type for PCU groups
-	InstanceType InstanceType `json:"instanceType"`
+	InstanceType string `json:"instanceType"`
 
 	// Max Maximum shared hourly PCUs in the PCU group
 	Max int `json:"max"`
@@ -1058,7 +1049,7 @@ type PCUGroupUpdateRequest struct {
 	Description *string `json:"description,omitempty"`
 
 	// InstanceType Instance type for PCU groups
-	InstanceType InstanceType `json:"instanceType"`
+	InstanceType string `json:"instanceType"`
 
 	// Max Maximum shared hourly PCUs in the PCU group
 	Max int `json:"max"`

--- a/astra/astra.gen.go
+++ b/astra/astra.gen.go
@@ -68,9 +68,9 @@ const (
 
 // Defines values for DatacenterRegionClassification.
 const (
-	DatacenterRegionClassificationPremium     DatacenterRegionClassification = "premium"
-	DatacenterRegionClassificationPremiumPlus DatacenterRegionClassification = "premium_plus"
-	DatacenterRegionClassificationStandard    DatacenterRegionClassification = "standard"
+	Premium     DatacenterRegionClassification = "premium"
+	PremiumPlus DatacenterRegionClassification = "premium_plus"
+	Standard    DatacenterRegionClassification = "standard"
 )
 
 // Defines values for DatacenterRegionZone.
@@ -158,8 +158,8 @@ const (
 
 // Defines values for PrivateLinkEndpointStatus.
 const (
-	PrivateLinkEndpointStatusAccepted PrivateLinkEndpointStatus = "Accepted"
-	PrivateLinkEndpointStatusRejected PrivateLinkEndpointStatus = "Rejected"
+	Accepted PrivateLinkEndpointStatus = "Accepted"
+	Rejected PrivateLinkEndpointStatus = "Rejected"
 )
 
 // Defines values for ProvisionType.
@@ -170,21 +170,21 @@ const (
 
 // Defines values for StatusEnum.
 const (
-	StatusEnumACTIVE       StatusEnum = "ACTIVE"
-	StatusEnumERROR        StatusEnum = "ERROR"
-	StatusEnumINITIALIZING StatusEnum = "INITIALIZING"
-	StatusEnumMAINTENANCE  StatusEnum = "MAINTENANCE"
-	StatusEnumPARKED       StatusEnum = "PARKED"
-	StatusEnumPARKING      StatusEnum = "PARKING"
-	StatusEnumPENDING      StatusEnum = "PENDING"
-	StatusEnumPREPARED     StatusEnum = "PREPARED"
-	StatusEnumPREPARING    StatusEnum = "PREPARING"
-	StatusEnumRESIZING     StatusEnum = "RESIZING"
-	StatusEnumSUSPENDED    StatusEnum = "SUSPENDED"
-	StatusEnumTERMINATED   StatusEnum = "TERMINATED"
-	StatusEnumTERMINATING  StatusEnum = "TERMINATING"
-	StatusEnumUNKNOWN      StatusEnum = "UNKNOWN"
-	StatusEnumUNPARKING    StatusEnum = "UNPARKING"
+	ACTIVE       StatusEnum = "ACTIVE"
+	ERROR        StatusEnum = "ERROR"
+	INITIALIZING StatusEnum = "INITIALIZING"
+	MAINTENANCE  StatusEnum = "MAINTENANCE"
+	PARKED       StatusEnum = "PARKED"
+	PARKING      StatusEnum = "PARKING"
+	PENDING      StatusEnum = "PENDING"
+	PREPARED     StatusEnum = "PREPARED"
+	PREPARING    StatusEnum = "PREPARING"
+	RESIZING     StatusEnum = "RESIZING"
+	SUSPENDED    StatusEnum = "SUSPENDED"
+	TERMINATED   StatusEnum = "TERMINATED"
+	TERMINATING  StatusEnum = "TERMINATING"
+	UNKNOWN      StatusEnum = "UNKNOWN"
+	UNPARKING    StatusEnum = "UNPARKING"
 )
 
 // Defines values for Tier.

--- a/astra/astra.gen.go
+++ b/astra/astra.gen.go
@@ -68,9 +68,9 @@ const (
 
 // Defines values for DatacenterRegionClassification.
 const (
-	Premium     DatacenterRegionClassification = "premium"
-	PremiumPlus DatacenterRegionClassification = "premium_plus"
-	Standard    DatacenterRegionClassification = "standard"
+	DatacenterRegionClassificationPremium     DatacenterRegionClassification = "premium"
+	DatacenterRegionClassificationPremiumPlus DatacenterRegionClassification = "premium_plus"
+	DatacenterRegionClassificationStandard    DatacenterRegionClassification = "standard"
 )
 
 // Defines values for DatacenterRegionZone.
@@ -79,6 +79,29 @@ const (
 	Emea DatacenterRegionZone = "emea"
 	Na   DatacenterRegionZone = "na"
 	Sa   DatacenterRegionZone = "sa"
+)
+
+// Defines values for InstanceType.
+const (
+	InstanceTypeStandard         InstanceType = "standard"
+	InstanceTypeStorageOptimized InstanceType = "storageOptimized"
+)
+
+// Defines values for PCUAssociationStatus.
+const (
+	PCUAssociationStatusAccepted PCUAssociationStatus = "Accepted"
+	PCUAssociationStatusCreated  PCUAssociationStatus = "Created"
+)
+
+// Defines values for PCUGroupStatus.
+const (
+	PCUGroupStatusACTIVE       PCUGroupStatus = "ACTIVE"
+	PCUGroupStatusCREATED      PCUGroupStatus = "CREATED"
+	PCUGroupStatusINITIALIZING PCUGroupStatus = "INITIALIZING"
+	PCUGroupStatusPARKED       PCUGroupStatus = "PARKED"
+	PCUGroupStatusPARKING      PCUGroupStatus = "PARKING"
+	PCUGroupStatusPLACING      PCUGroupStatus = "PLACING"
+	PCUGroupStatusUNPARKING    PCUGroupStatus = "UNPARKING"
 )
 
 // Defines values for PolicyEffect.
@@ -135,27 +158,33 @@ const (
 
 // Defines values for PrivateLinkEndpointStatus.
 const (
-	Accepted PrivateLinkEndpointStatus = "Accepted"
-	Rejected PrivateLinkEndpointStatus = "Rejected"
+	PrivateLinkEndpointStatusAccepted PrivateLinkEndpointStatus = "Accepted"
+	PrivateLinkEndpointStatusRejected PrivateLinkEndpointStatus = "Rejected"
+)
+
+// Defines values for ProvisionType.
+const (
+	Dedicated ProvisionType = "dedicated"
+	Shared    ProvisionType = "shared"
 )
 
 // Defines values for StatusEnum.
 const (
-	ACTIVE       StatusEnum = "ACTIVE"
-	ERROR        StatusEnum = "ERROR"
-	INITIALIZING StatusEnum = "INITIALIZING"
-	MAINTENANCE  StatusEnum = "MAINTENANCE"
-	PARKED       StatusEnum = "PARKED"
-	PARKING      StatusEnum = "PARKING"
-	PENDING      StatusEnum = "PENDING"
-	PREPARED     StatusEnum = "PREPARED"
-	PREPARING    StatusEnum = "PREPARING"
-	RESIZING     StatusEnum = "RESIZING"
-	SUSPENDED    StatusEnum = "SUSPENDED"
-	TERMINATED   StatusEnum = "TERMINATED"
-	TERMINATING  StatusEnum = "TERMINATING"
-	UNKNOWN      StatusEnum = "UNKNOWN"
-	UNPARKING    StatusEnum = "UNPARKING"
+	StatusEnumACTIVE       StatusEnum = "ACTIVE"
+	StatusEnumERROR        StatusEnum = "ERROR"
+	StatusEnumINITIALIZING StatusEnum = "INITIALIZING"
+	StatusEnumMAINTENANCE  StatusEnum = "MAINTENANCE"
+	StatusEnumPARKED       StatusEnum = "PARKED"
+	StatusEnumPARKING      StatusEnum = "PARKING"
+	StatusEnumPENDING      StatusEnum = "PENDING"
+	StatusEnumPREPARED     StatusEnum = "PREPARED"
+	StatusEnumPREPARING    StatusEnum = "PREPARING"
+	StatusEnumRESIZING     StatusEnum = "RESIZING"
+	StatusEnumSUSPENDED    StatusEnum = "SUSPENDED"
+	StatusEnumTERMINATED   StatusEnum = "TERMINATED"
+	StatusEnumTERMINATING  StatusEnum = "TERMINATING"
+	StatusEnumUNKNOWN      StatusEnum = "UNKNOWN"
+	StatusEnumUNPARKING    StatusEnum = "UNPARKING"
 )
 
 // Defines values for Tier.
@@ -776,6 +805,9 @@ type GoogleVPC struct {
 	VpcNetworkName string `json:"vpcNetworkName"`
 }
 
+// InstanceType Instance type for PCU groups
+type InstanceType string
+
 // KafkaBootstrapServer Kafka bootstrap server
 type KafkaBootstrapServer = string
 
@@ -902,8 +934,8 @@ type PCUAssociation struct {
 	// PcuGroupUUID PCU group this association belongs to
 	PcuGroupUUID *string `json:"pcuGroupUUID,omitempty"`
 
-	// ProvisioningStatus Provisioning status of the PCU association
-	ProvisioningStatus *string `json:"provisioningStatus,omitempty"`
+	// ProvisioningStatus PCU Association provisioning status
+	ProvisioningStatus *PCUAssociationStatus `json:"provisioningStatus,omitempty"`
 
 	// UpdatedAt Update time of the PCU association
 	UpdatedAt *string `json:"updatedAt,omitempty"`
@@ -911,6 +943,9 @@ type PCUAssociation struct {
 	// UpdatedBy User who updated the PCU association
 	UpdatedBy *string `json:"updatedBy,omitempty"`
 }
+
+// PCUAssociationStatus PCU Association provisioning status
+type PCUAssociationStatus string
 
 // PCUAssociationTransferRequest PCU association transfer
 type PCUAssociationTransferRequest struct {
@@ -926,8 +961,8 @@ type PCUAssociationTransferRequest struct {
 
 // PCUGroup PCU Group Model
 type PCUGroup struct {
-	// CloudProvider Cloud provider of the PCU group
-	CloudProvider *string `json:"cloudProvider,omitempty"`
+	// CloudProvider Cloud hosting provider
+	CloudProvider *CloudProvider `json:"cloudProvider,omitempty"`
 
 	// CreatedAt Creation time of the PCU group
 	CreatedAt *string `json:"createdAt,omitempty"`
@@ -938,8 +973,8 @@ type PCUGroup struct {
 	// Description Description of the PCU group
 	Description *string `json:"description,omitempty"`
 
-	// InstanceType Instance type of the PCU group
-	InstanceType *string `json:"instanceType,omitempty"`
+	// InstanceType Instance type for PCU groups
+	InstanceType *InstanceType `json:"instanceType,omitempty"`
 
 	// Max Maximum shared hourly PCUs in the PCU group
 	Max *int `json:"max,omitempty"`
@@ -950,8 +985,8 @@ type PCUGroup struct {
 	// OrgId Organization ID
 	OrgId *string `json:"orgId,omitempty"`
 
-	// ProvisionType Provision type of the PCU group
-	ProvisionType *string `json:"provisionType,omitempty"`
+	// ProvisionType Provision type for PCU groups
+	ProvisionType *ProvisionType `json:"provisionType,omitempty"`
 
 	// Region Region of the PCU group
 	Region *string `json:"region,omitempty"`
@@ -959,8 +994,8 @@ type PCUGroup struct {
 	// Reserved Absolute required PCUs in the PCU group
 	Reserved *int `json:"reserved,omitempty"`
 
-	// Status Status of the PCU Group
-	Status *string `json:"status,omitempty"`
+	// Status PCU Group lifecycle status
+	Status *PCUGroupStatus `json:"status,omitempty"`
 
 	// Title Title of the PCU group
 	Title *string `json:"title,omitempty"`
@@ -977,14 +1012,14 @@ type PCUGroup struct {
 
 // PCUGroupCreateRequest PCU Group Create Request Model
 type PCUGroupCreateRequest struct {
-	// CloudProvider Cloud provider of the PCU group
-	CloudProvider *string `json:"cloudProvider,omitempty"`
+	// CloudProvider Cloud hosting provider
+	CloudProvider *CloudProvider `json:"cloudProvider,omitempty"`
 
 	// Description Description of the PCU group
 	Description *string `json:"description,omitempty"`
 
-	// InstanceType Instance type of the PCU group
-	InstanceType *string `json:"instanceType,omitempty"`
+	// InstanceType Instance type for PCU groups
+	InstanceType *InstanceType `json:"instanceType,omitempty"`
 
 	// Max Maximum shared hourly PCUs in the PCU group
 	Max *int `json:"max,omitempty"`
@@ -995,8 +1030,8 @@ type PCUGroupCreateRequest struct {
 	// OrgID OrganizationID of the PCU group, ignored for authenticated users
 	OrgID *string `json:"orgID,omitempty"`
 
-	// ProvisionType Provision type of the PCU group
-	ProvisionType *string `json:"provisionType,omitempty"`
+	// ProvisionType Provision type for PCU groups
+	ProvisionType *ProvisionType `json:"provisionType,omitempty"`
 
 	// Region Region of the PCU group
 	Region *string `json:"region,omitempty"`
@@ -1014,13 +1049,16 @@ type PCUGroupGetRequest struct {
 	PcuGroupUUIDs *[]string `json:"pcuGroupUUIDs,omitempty"`
 }
 
+// PCUGroupStatus PCU Group lifecycle status
+type PCUGroupStatus string
+
 // PCUGroupUpdateRequest PCU Group Update Request Model
 type PCUGroupUpdateRequest struct {
 	// Description Description of the PCU group
 	Description *string `json:"description,omitempty"`
 
-	// InstanceType Instance type of the PCU group
-	InstanceType *string `json:"instanceType,omitempty"`
+	// InstanceType Instance type for PCU groups
+	InstanceType *InstanceType `json:"instanceType,omitempty"`
 
 	// Max Maximum shared hourly PCUs in the PCU group
 	Max *int `json:"max,omitempty"`
@@ -1031,8 +1069,8 @@ type PCUGroupUpdateRequest struct {
 	// PcuGroupUUID UUID of the PCU group to update
 	PcuGroupUUID *string `json:"pcuGroupUUID,omitempty"`
 
-	// ProvisionType Provision type of the PCU group
-	ProvisionType *string `json:"provisionType,omitempty"`
+	// ProvisionType Provision type for PCU groups
+	ProvisionType *ProvisionType `json:"provisionType,omitempty"`
 
 	// Reserved Absolute required PCUs in the PCU group
 	Reserved *int `json:"reserved,omitempty"`
@@ -1148,6 +1186,9 @@ type PrivateLinkUpdateEndpointInput struct {
 	// Description User defined description of the endpoint
 	Description *string `json:"description,omitempty"`
 }
+
+// ProvisionType Provision type for PCU groups
+type ProvisionType string
 
 // Role Details of a user role and its policy details
 type Role struct {
@@ -8068,6 +8109,7 @@ type PcuCreateResponse struct {
 	HTTPResponse *http.Response
 	JSON201      *[]PCUGroup
 	JSON400      *BadRequest
+	JSON403      *Forbidden
 	JSON5XX      *ServerError
 }
 
@@ -8090,7 +8132,10 @@ func (r PcuCreateResponse) StatusCode() int {
 type PcuUpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	JSON200      *[]PCUGroup
 	JSON400      *BadRequest
+	JSON403      *Forbidden
+	JSON404      *NotFound
 	JSON5XX      *ServerError
 }
 
@@ -8115,6 +8160,8 @@ type PcuGetResponse struct {
 	HTTPResponse *http.Response
 	JSON200      *[]PCUGroup
 	JSON400      *BadRequest
+	JSON403      *Forbidden
+	JSON404      *NotFound
 	JSON5XX      *ServerError
 }
 
@@ -8138,6 +8185,7 @@ type PcuAssociationTransferResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON400      *BadRequest
+	JSON403      *Forbidden
 	JSON5XX      *ServerError
 }
 
@@ -8162,6 +8210,8 @@ type PcuAssociationGetResponse struct {
 	HTTPResponse *http.Response
 	JSON200      *[]PCUAssociation
 	JSON400      *BadRequest
+	JSON403      *Forbidden
+	JSON404      *NotFound
 	JSON5XX      *ServerError
 }
 
@@ -8185,6 +8235,8 @@ type PcuAssociationDeleteResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON400      *BadRequest
+	JSON403      *Forbidden
+	JSON404      *NotFound
 	JSON5XX      *ServerError
 }
 
@@ -8208,6 +8260,8 @@ type PcuAssociationCreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON400      *BadRequest
+	JSON403      *Forbidden
+	JSON404      *NotFound
 	JSON5XX      *ServerError
 }
 
@@ -8231,6 +8285,7 @@ type PcuGroupParkResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON400      *BadRequest
+	JSON403      *Forbidden
 	JSON5XX      *ServerError
 }
 
@@ -8254,6 +8309,7 @@ type PcuGroupUnparkResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON400      *BadRequest
+	JSON403      *Forbidden
 	JSON5XX      *ServerError
 }
 
@@ -8277,6 +8333,8 @@ type PcuDeleteResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON400      *BadRequest
+	JSON403      *Forbidden
+	JSON404      *NotFound
 	JSON5XX      *ServerError
 }
 
@@ -11990,6 +12048,13 @@ func ParsePcuCreateResponse(rsp *http.Response) (*PcuCreateResponse, error) {
 		}
 		response.JSON400 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
 		var dest ServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -12016,12 +12081,33 @@ func ParsePcuUpdateResponse(rsp *http.Response) (*PcuUpdateResponse, error) {
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []PCUGroup
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
 		var dest BadRequest
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
 		var dest ServerError
@@ -12063,6 +12149,20 @@ func ParsePcuGetResponse(rsp *http.Response) (*PcuGetResponse, error) {
 		}
 		response.JSON400 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
 		var dest ServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -12095,6 +12195,13 @@ func ParsePcuAssociationTransferResponse(rsp *http.Response) (*PcuAssociationTra
 			return nil, err
 		}
 		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
 		var dest ServerError
@@ -12136,6 +12243,20 @@ func ParsePcuAssociationGetResponse(rsp *http.Response) (*PcuAssociationGetRespo
 		}
 		response.JSON400 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
 		var dest ServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -12168,6 +12289,20 @@ func ParsePcuAssociationDeleteResponse(rsp *http.Response) (*PcuAssociationDelet
 			return nil, err
 		}
 		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
 		var dest ServerError
@@ -12202,6 +12337,20 @@ func ParsePcuAssociationCreateResponse(rsp *http.Response) (*PcuAssociationCreat
 		}
 		response.JSON400 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
 		var dest ServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -12234,6 +12383,13 @@ func ParsePcuGroupParkResponse(rsp *http.Response) (*PcuGroupParkResponse, error
 			return nil, err
 		}
 		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
 		var dest ServerError
@@ -12268,6 +12424,13 @@ func ParsePcuGroupUnparkResponse(rsp *http.Response) (*PcuGroupUnparkResponse, e
 		}
 		response.JSON400 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
 		var dest ServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -12300,6 +12463,20 @@ func ParsePcuDeleteResponse(rsp *http.Response) (*PcuDeleteResponse, error) {
 			return nil, err
 		}
 		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
 		var dest ServerError

--- a/astra/astra.gen.go
+++ b/astra/astra.gen.go
@@ -1013,34 +1013,34 @@ type PCUGroup struct {
 // PCUGroupCreateRequest PCU Group Create Request Model
 type PCUGroupCreateRequest struct {
 	// CloudProvider Cloud hosting provider
-	CloudProvider *CloudProvider `json:"cloudProvider,omitempty"`
+	CloudProvider CloudProvider `json:"cloudProvider"`
 
 	// Description Description of the PCU group
 	Description *string `json:"description,omitempty"`
 
 	// InstanceType Instance type for PCU groups
-	InstanceType *InstanceType `json:"instanceType,omitempty"`
+	InstanceType InstanceType `json:"instanceType"`
 
 	// Max Maximum shared hourly PCUs in the PCU group
-	Max *int `json:"max,omitempty"`
+	Max int `json:"max"`
 
 	// Min Minimum shared hourly PCUs in the PCU group
-	Min *int `json:"min,omitempty"`
+	Min int `json:"min"`
 
 	// OrgID OrganizationID of the PCU group, ignored for authenticated users
 	OrgID *string `json:"orgID,omitempty"`
 
 	// ProvisionType Provision type for PCU groups
-	ProvisionType *ProvisionType `json:"provisionType,omitempty"`
+	ProvisionType ProvisionType `json:"provisionType"`
 
 	// Region Region of the PCU group
-	Region *string `json:"region,omitempty"`
+	Region string `json:"region"`
 
 	// Reserved Absolute required PCUs in the PCU group
-	Reserved *int `json:"reserved,omitempty"`
+	Reserved int `json:"reserved"`
 
 	// Title Title of the PCU group
-	Title *string `json:"title,omitempty"`
+	Title string `json:"title"`
 }
 
 // PCUGroupGetRequest PCU groups to get
@@ -1058,25 +1058,25 @@ type PCUGroupUpdateRequest struct {
 	Description *string `json:"description,omitempty"`
 
 	// InstanceType Instance type for PCU groups
-	InstanceType *InstanceType `json:"instanceType,omitempty"`
+	InstanceType InstanceType `json:"instanceType"`
 
 	// Max Maximum shared hourly PCUs in the PCU group
-	Max *int `json:"max,omitempty"`
+	Max int `json:"max"`
 
 	// Min Minimum shared hourly PCUs in the PCU group
-	Min *int `json:"min,omitempty"`
+	Min int `json:"min"`
 
 	// PcuGroupUUID UUID of the PCU group to update
-	PcuGroupUUID *string `json:"pcuGroupUUID,omitempty"`
+	PcuGroupUUID string `json:"pcuGroupUUID"`
 
 	// ProvisionType Provision type for PCU groups
-	ProvisionType *ProvisionType `json:"provisionType,omitempty"`
+	ProvisionType ProvisionType `json:"provisionType"`
 
 	// Reserved Absolute required PCUs in the PCU group
-	Reserved *int `json:"reserved,omitempty"`
+	Reserved int `json:"reserved"`
 
 	// Title Title of the PCU group
-	Title *string `json:"title,omitempty"`
+	Title string `json:"title"`
 }
 
 // Policy A policy for a role in Astra.

--- a/astra/astra.gen.go
+++ b/astra/astra.gen.go
@@ -83,8 +83,8 @@ const (
 
 // Defines values for InstanceType.
 const (
-	InstanceTypeStandard         InstanceType = "standard"
-	InstanceTypeStorageOptimized InstanceType = "storageOptimized"
+	PcuInstanceTypeStandard         InstanceType = "standard"
+	PcuInstanceTypeStorageOptimized InstanceType = "storageOptimized"
 )
 
 // Defines values for PCUAssociationStatus.
@@ -164,8 +164,8 @@ const (
 
 // Defines values for ProvisionType.
 const (
-	Dedicated ProvisionType = "dedicated"
-	Shared    ProvisionType = "shared"
+	PcuProvisionTypeDedicated ProvisionType = "dedicated"
+	PcuProvisionTypeShared    ProvisionType = "shared"
 )
 
 // Defines values for StatusEnum.

--- a/astra/astra.gen.go
+++ b/astra/astra.gen.go
@@ -888,6 +888,159 @@ type OrganizationUsers struct {
 	Users []UserResponse `json:"users"`
 }
 
+// PCUAssociation PCUAssociation information
+type PCUAssociation struct {
+	// CreatedAt Creation time of the PCU association
+	CreatedAt *string `json:"createdAt,omitempty"`
+
+	// CreatedBy User who created the PCU association
+	CreatedBy *string `json:"createdBy,omitempty"`
+
+	// DatacenterUUID Datacenter UUID of the PCU association
+	DatacenterUUID *string `json:"datacenterUUID,omitempty"`
+
+	// PcuGroupUUID PCU group this association belongs to
+	PcuGroupUUID *string `json:"pcuGroupUUID,omitempty"`
+
+	// ProvisioningStatus Provisioning status of the PCU association
+	ProvisioningStatus *string `json:"provisioningStatus,omitempty"`
+
+	// UpdatedAt Update time of the PCU association
+	UpdatedAt *string `json:"updatedAt,omitempty"`
+
+	// UpdatedBy User who updated the PCU association
+	UpdatedBy *string `json:"updatedBy,omitempty"`
+}
+
+// PCUAssociationTransferRequest PCU association transfer
+type PCUAssociationTransferRequest struct {
+	// DatacenterUUID The Datacenter UUID that is part of the fromPCUGroupUUID which we want to move to the toPCUGroupUUID
+	DatacenterUUID *string `json:"datacenterUUID,omitempty"`
+
+	// FromPCUGroupUUID The PCU Group UUID from which we want to move an association
+	FromPCUGroupUUID *string `json:"fromPCUGroupUUID,omitempty"`
+
+	// ToPCUGroupUUID The PCU Group UUID to which we want to move the association
+	ToPCUGroupUUID *string `json:"toPCUGroupUUID,omitempty"`
+}
+
+// PCUGroup PCU Group Model
+type PCUGroup struct {
+	// CloudProvider Cloud provider of the PCU group
+	CloudProvider *string `json:"cloudProvider,omitempty"`
+
+	// CreatedAt Creation time of the PCU group
+	CreatedAt *string `json:"createdAt,omitempty"`
+
+	// CreatedBy User who created the PCU group
+	CreatedBy *string `json:"createdBy,omitempty"`
+
+	// Description Description of the PCU group
+	Description *string `json:"description,omitempty"`
+
+	// InstanceType Instance type of the PCU group
+	InstanceType *string `json:"instanceType,omitempty"`
+
+	// Max Maximum shared hourly PCUs in the PCU group
+	Max *int `json:"max,omitempty"`
+
+	// Min Minimum shared hourly PCUs in the PCU group
+	Min *int `json:"min,omitempty"`
+
+	// OrgId Organization ID
+	OrgId *string `json:"orgId,omitempty"`
+
+	// ProvisionType Provision type of the PCU group
+	ProvisionType *string `json:"provisionType,omitempty"`
+
+	// Region Region of the PCU group
+	Region *string `json:"region,omitempty"`
+
+	// Reserved Absolute required PCUs in the PCU group
+	Reserved *int `json:"reserved,omitempty"`
+
+	// Status Status of the PCU Group
+	Status *string `json:"status,omitempty"`
+
+	// Title Title of the PCU group
+	Title *string `json:"title,omitempty"`
+
+	// UpdatedAt Update time of the PCU group
+	UpdatedAt *string `json:"updatedAt,omitempty"`
+
+	// UpdatedBy User who updated the PCU group
+	UpdatedBy *string `json:"updatedBy,omitempty"`
+
+	// Uuid UUID of the PCU group
+	Uuid *string `json:"uuid,omitempty"`
+}
+
+// PCUGroupCreateRequest PCU Group Create Request Model
+type PCUGroupCreateRequest struct {
+	// CloudProvider Cloud provider of the PCU group
+	CloudProvider *string `json:"cloudProvider,omitempty"`
+
+	// Description Description of the PCU group
+	Description *string `json:"description,omitempty"`
+
+	// InstanceType Instance type of the PCU group
+	InstanceType *string `json:"instanceType,omitempty"`
+
+	// Max Maximum shared hourly PCUs in the PCU group
+	Max *int `json:"max,omitempty"`
+
+	// Min Minimum shared hourly PCUs in the PCU group
+	Min *int `json:"min,omitempty"`
+
+	// OrgID OrganizationID of the PCU group, ignored for authenticated users
+	OrgID *string `json:"orgID,omitempty"`
+
+	// ProvisionType Provision type of the PCU group
+	ProvisionType *string `json:"provisionType,omitempty"`
+
+	// Region Region of the PCU group
+	Region *string `json:"region,omitempty"`
+
+	// Reserved Absolute required PCUs in the PCU group
+	Reserved *int `json:"reserved,omitempty"`
+
+	// Title Title of the PCU group
+	Title *string `json:"title,omitempty"`
+}
+
+// PCUGroupGetRequest PCU groups to get
+type PCUGroupGetRequest struct {
+	// PcuGroupUUIDs PCU group UIDs
+	PcuGroupUUIDs *[]string `json:"pcuGroupUUIDs,omitempty"`
+}
+
+// PCUGroupUpdateRequest PCU Group Update Request Model
+type PCUGroupUpdateRequest struct {
+	// Description Description of the PCU group
+	Description *string `json:"description,omitempty"`
+
+	// InstanceType Instance type of the PCU group
+	InstanceType *string `json:"instanceType,omitempty"`
+
+	// Max Maximum shared hourly PCUs in the PCU group
+	Max *int `json:"max,omitempty"`
+
+	// Min Minimum shared hourly PCUs in the PCU group
+	Min *int `json:"min,omitempty"`
+
+	// PcuGroupUUID UUID of the PCU group to update
+	PcuGroupUUID *string `json:"pcuGroupUUID,omitempty"`
+
+	// ProvisionType Provision type of the PCU group
+	ProvisionType *string `json:"provisionType,omitempty"`
+
+	// Reserved Absolute required PCUs in the PCU group
+	Reserved *int `json:"reserved,omitempty"`
+
+	// Title Title of the PCU group
+	Title *string `json:"title,omitempty"`
+}
+
 // Policy A policy for a role in Astra.
 type Policy struct {
 	// Actions The actions this policy can take. Example Actions: 'org-billing-write' 'db-keyspace-create'
@@ -1250,6 +1403,12 @@ type TerminateDatabaseParams struct {
 	PreparedStateOnly *bool `form:"preparedStateOnly,omitempty" json:"preparedStateOnly,omitempty"`
 }
 
+// PcuCreateJSONBody defines parameters for PcuCreate.
+type PcuCreateJSONBody = []PCUGroupCreateRequest
+
+// PcuUpdateJSONBody defines parameters for PcuUpdate.
+type PcuUpdateJSONBody = []PCUGroupUpdateRequest
+
 // DeleteVPCPeeringConnectionParamsProvider defines parameters for DeleteVPCPeeringConnection.
 type DeleteVPCPeeringConnectionParamsProvider string
 
@@ -1338,6 +1497,18 @@ type InviteUserToOrganizationJSONRequestBody = UserInvite
 
 // UpdateRolesForUserInOrganizationJSONRequestBody defines body for UpdateRolesForUserInOrganization for application/json ContentType.
 type UpdateRolesForUserInOrganizationJSONRequestBody = RoleInviteRequest
+
+// PcuCreateJSONRequestBody defines body for PcuCreate for application/json ContentType.
+type PcuCreateJSONRequestBody = PcuCreateJSONBody
+
+// PcuUpdateJSONRequestBody defines body for PcuUpdate for application/json ContentType.
+type PcuUpdateJSONRequestBody = PcuUpdateJSONBody
+
+// PcuGetJSONRequestBody defines body for PcuGet for application/json ContentType.
+type PcuGetJSONRequestBody = PCUGroupGetRequest
+
+// PcuAssociationTransferJSONRequestBody defines body for PcuAssociationTransfer for application/json ContentType.
+type PcuAssociationTransferJSONRequestBody = PCUAssociationTransferRequest
 
 // CreateVPCPeeringConnectionJSONRequestBody defines body for CreateVPCPeeringConnection for application/json ContentType.
 type CreateVPCPeeringConnectionJSONRequestBody CreateVPCPeeringConnectionJSONBody
@@ -1638,6 +1809,44 @@ type ClientInterface interface {
 	UpdateRolesForUserInOrganizationWithBody(ctx context.Context, userID UserIdParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UpdateRolesForUserInOrganization(ctx context.Context, userID UserIdParam, body UpdateRolesForUserInOrganizationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PcuCreateWithBody request with any body
+	PcuCreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PcuCreate(ctx context.Context, body PcuCreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PcuUpdateWithBody request with any body
+	PcuUpdateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PcuUpdate(ctx context.Context, body PcuUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PcuGetWithBody request with any body
+	PcuGetWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PcuGet(ctx context.Context, body PcuGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PcuAssociationTransferWithBody request with any body
+	PcuAssociationTransferWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PcuAssociationTransfer(ctx context.Context, body PcuAssociationTransferJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PcuAssociationGet request
+	PcuAssociationGet(ctx context.Context, pcuGroupUUID string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PcuAssociationDelete request
+	PcuAssociationDelete(ctx context.Context, pcuGroupUUID string, datacenterUUID string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PcuAssociationCreate request
+	PcuAssociationCreate(ctx context.Context, pcuGroupUUID string, datacenterUUID string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PcuGroupPark request
+	PcuGroupPark(ctx context.Context, pcuGroupUUID string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PcuGroupUnpark request
+	PcuGroupUnpark(ctx context.Context, pcuGroupUUID string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PcuDelete request
+	PcuDelete(ctx context.Context, pcuGroupUUID string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DeleteVPCPeeringConnection request
 	DeleteVPCPeeringConnection(ctx context.Context, provider DeleteVPCPeeringConnectionParamsProvider, databaseID string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2606,6 +2815,174 @@ func (c *Client) UpdateRolesForUserInOrganizationWithBody(ctx context.Context, u
 
 func (c *Client) UpdateRolesForUserInOrganization(ctx context.Context, userID UserIdParam, body UpdateRolesForUserInOrganizationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateRolesForUserInOrganizationRequest(c.Server, userID, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PcuCreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPcuCreateRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PcuCreate(ctx context.Context, body PcuCreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPcuCreateRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PcuUpdateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPcuUpdateRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PcuUpdate(ctx context.Context, body PcuUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPcuUpdateRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PcuGetWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPcuGetRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PcuGet(ctx context.Context, body PcuGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPcuGetRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PcuAssociationTransferWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPcuAssociationTransferRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PcuAssociationTransfer(ctx context.Context, body PcuAssociationTransferJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPcuAssociationTransferRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PcuAssociationGet(ctx context.Context, pcuGroupUUID string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPcuAssociationGetRequest(c.Server, pcuGroupUUID)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PcuAssociationDelete(ctx context.Context, pcuGroupUUID string, datacenterUUID string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPcuAssociationDeleteRequest(c.Server, pcuGroupUUID, datacenterUUID)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PcuAssociationCreate(ctx context.Context, pcuGroupUUID string, datacenterUUID string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPcuAssociationCreateRequest(c.Server, pcuGroupUUID, datacenterUUID)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PcuGroupPark(ctx context.Context, pcuGroupUUID string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPcuGroupParkRequest(c.Server, pcuGroupUUID)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PcuGroupUnpark(ctx context.Context, pcuGroupUUID string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPcuGroupUnparkRequest(c.Server, pcuGroupUUID)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PcuDelete(ctx context.Context, pcuGroupUUID string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPcuDeleteRequest(c.Server, pcuGroupUUID)
 	if err != nil {
 		return nil, err
 	}
@@ -5130,6 +5507,384 @@ func NewUpdateRolesForUserInOrganizationRequestWithBody(server string, userID Us
 	return req, nil
 }
 
+// NewPcuCreateRequest calls the generic PcuCreate builder with application/json body
+func NewPcuCreateRequest(server string, body PcuCreateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPcuCreateRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPcuCreateRequestWithBody generates requests for PcuCreate with any type of body
+func NewPcuCreateRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/pcus")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewPcuUpdateRequest calls the generic PcuUpdate builder with application/json body
+func NewPcuUpdateRequest(server string, body PcuUpdateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPcuUpdateRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPcuUpdateRequestWithBody generates requests for PcuUpdate with any type of body
+func NewPcuUpdateRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/pcus")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewPcuGetRequest calls the generic PcuGet builder with application/json body
+func NewPcuGetRequest(server string, body PcuGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPcuGetRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPcuGetRequestWithBody generates requests for PcuGet with any type of body
+func NewPcuGetRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/pcus/actions/get")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewPcuAssociationTransferRequest calls the generic PcuAssociationTransfer builder with application/json body
+func NewPcuAssociationTransferRequest(server string, body PcuAssociationTransferJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPcuAssociationTransferRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPcuAssociationTransferRequestWithBody generates requests for PcuAssociationTransfer with any type of body
+func NewPcuAssociationTransferRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/pcus/association/transfer")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewPcuAssociationGetRequest generates requests for PcuAssociationGet
+func NewPcuAssociationGetRequest(server string, pcuGroupUUID string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "pcuGroupUUID", runtime.ParamLocationPath, pcuGroupUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/pcus/association/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPcuAssociationDeleteRequest generates requests for PcuAssociationDelete
+func NewPcuAssociationDeleteRequest(server string, pcuGroupUUID string, datacenterUUID string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "pcuGroupUUID", runtime.ParamLocationPath, pcuGroupUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "datacenterUUID", runtime.ParamLocationPath, datacenterUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/pcus/association/%s/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPcuAssociationCreateRequest generates requests for PcuAssociationCreate
+func NewPcuAssociationCreateRequest(server string, pcuGroupUUID string, datacenterUUID string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "pcuGroupUUID", runtime.ParamLocationPath, pcuGroupUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "datacenterUUID", runtime.ParamLocationPath, datacenterUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/pcus/association/%s/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPcuGroupParkRequest generates requests for PcuGroupPark
+func NewPcuGroupParkRequest(server string, pcuGroupUUID string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "pcuGroupUUID", runtime.ParamLocationPath, pcuGroupUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/pcus/park/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPcuGroupUnparkRequest generates requests for PcuGroupUnpark
+func NewPcuGroupUnparkRequest(server string, pcuGroupUUID string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "pcuGroupUUID", runtime.ParamLocationPath, pcuGroupUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/pcus/unpark/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPcuDeleteRequest generates requests for PcuDelete
+func NewPcuDeleteRequest(server string, pcuGroupUUID string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "pcuGroupUUID", runtime.ParamLocationPath, pcuGroupUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/pcus/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewDeleteVPCPeeringConnectionRequest generates requests for DeleteVPCPeeringConnection
 func NewDeleteVPCPeeringConnectionRequest(server string, provider DeleteVPCPeeringConnectionParamsProvider, databaseID string) (*http.Request, error) {
 	var err error
@@ -5848,6 +6603,44 @@ type ClientWithResponsesInterface interface {
 	UpdateRolesForUserInOrganizationWithBodyWithResponse(ctx context.Context, userID UserIdParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateRolesForUserInOrganizationResponse, error)
 
 	UpdateRolesForUserInOrganizationWithResponse(ctx context.Context, userID UserIdParam, body UpdateRolesForUserInOrganizationJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateRolesForUserInOrganizationResponse, error)
+
+	// PcuCreateWithBodyWithResponse request with any body
+	PcuCreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PcuCreateResponse, error)
+
+	PcuCreateWithResponse(ctx context.Context, body PcuCreateJSONRequestBody, reqEditors ...RequestEditorFn) (*PcuCreateResponse, error)
+
+	// PcuUpdateWithBodyWithResponse request with any body
+	PcuUpdateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PcuUpdateResponse, error)
+
+	PcuUpdateWithResponse(ctx context.Context, body PcuUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*PcuUpdateResponse, error)
+
+	// PcuGetWithBodyWithResponse request with any body
+	PcuGetWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PcuGetResponse, error)
+
+	PcuGetWithResponse(ctx context.Context, body PcuGetJSONRequestBody, reqEditors ...RequestEditorFn) (*PcuGetResponse, error)
+
+	// PcuAssociationTransferWithBodyWithResponse request with any body
+	PcuAssociationTransferWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PcuAssociationTransferResponse, error)
+
+	PcuAssociationTransferWithResponse(ctx context.Context, body PcuAssociationTransferJSONRequestBody, reqEditors ...RequestEditorFn) (*PcuAssociationTransferResponse, error)
+
+	// PcuAssociationGetWithResponse request
+	PcuAssociationGetWithResponse(ctx context.Context, pcuGroupUUID string, reqEditors ...RequestEditorFn) (*PcuAssociationGetResponse, error)
+
+	// PcuAssociationDeleteWithResponse request
+	PcuAssociationDeleteWithResponse(ctx context.Context, pcuGroupUUID string, datacenterUUID string, reqEditors ...RequestEditorFn) (*PcuAssociationDeleteResponse, error)
+
+	// PcuAssociationCreateWithResponse request
+	PcuAssociationCreateWithResponse(ctx context.Context, pcuGroupUUID string, datacenterUUID string, reqEditors ...RequestEditorFn) (*PcuAssociationCreateResponse, error)
+
+	// PcuGroupParkWithResponse request
+	PcuGroupParkWithResponse(ctx context.Context, pcuGroupUUID string, reqEditors ...RequestEditorFn) (*PcuGroupParkResponse, error)
+
+	// PcuGroupUnparkWithResponse request
+	PcuGroupUnparkWithResponse(ctx context.Context, pcuGroupUUID string, reqEditors ...RequestEditorFn) (*PcuGroupUnparkResponse, error)
+
+	// PcuDeleteWithResponse request
+	PcuDeleteWithResponse(ctx context.Context, pcuGroupUUID string, reqEditors ...RequestEditorFn) (*PcuDeleteResponse, error)
 
 	// DeleteVPCPeeringConnectionWithResponse request
 	DeleteVPCPeeringConnectionWithResponse(ctx context.Context, provider DeleteVPCPeeringConnectionParamsProvider, databaseID string, reqEditors ...RequestEditorFn) (*DeleteVPCPeeringConnectionResponse, error)
@@ -7270,6 +8063,239 @@ func (r UpdateRolesForUserInOrganizationResponse) StatusCode() int {
 	return 0
 }
 
+type PcuCreateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *[]PCUGroup
+	JSON400      *BadRequest
+	JSON5XX      *ServerError
+}
+
+// Status returns HTTPResponse.Status
+func (r PcuCreateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PcuCreateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PcuUpdateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *BadRequest
+	JSON5XX      *ServerError
+}
+
+// Status returns HTTPResponse.Status
+func (r PcuUpdateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PcuUpdateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PcuGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]PCUGroup
+	JSON400      *BadRequest
+	JSON5XX      *ServerError
+}
+
+// Status returns HTTPResponse.Status
+func (r PcuGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PcuGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PcuAssociationTransferResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *BadRequest
+	JSON5XX      *ServerError
+}
+
+// Status returns HTTPResponse.Status
+func (r PcuAssociationTransferResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PcuAssociationTransferResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PcuAssociationGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]PCUAssociation
+	JSON400      *BadRequest
+	JSON5XX      *ServerError
+}
+
+// Status returns HTTPResponse.Status
+func (r PcuAssociationGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PcuAssociationGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PcuAssociationDeleteResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *BadRequest
+	JSON5XX      *ServerError
+}
+
+// Status returns HTTPResponse.Status
+func (r PcuAssociationDeleteResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PcuAssociationDeleteResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PcuAssociationCreateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *BadRequest
+	JSON5XX      *ServerError
+}
+
+// Status returns HTTPResponse.Status
+func (r PcuAssociationCreateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PcuAssociationCreateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PcuGroupParkResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *BadRequest
+	JSON5XX      *ServerError
+}
+
+// Status returns HTTPResponse.Status
+func (r PcuGroupParkResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PcuGroupParkResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PcuGroupUnparkResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *BadRequest
+	JSON5XX      *ServerError
+}
+
+// Status returns HTTPResponse.Status
+func (r PcuGroupUnparkResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PcuGroupUnparkResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PcuDeleteResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *BadRequest
+	JSON5XX      *ServerError
+}
+
+// Status returns HTTPResponse.Status
+func (r PcuDeleteResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PcuDeleteResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type DeleteVPCPeeringConnectionResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -8196,6 +9222,128 @@ func (c *ClientWithResponses) UpdateRolesForUserInOrganizationWithResponse(ctx c
 		return nil, err
 	}
 	return ParseUpdateRolesForUserInOrganizationResponse(rsp)
+}
+
+// PcuCreateWithBodyWithResponse request with arbitrary body returning *PcuCreateResponse
+func (c *ClientWithResponses) PcuCreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PcuCreateResponse, error) {
+	rsp, err := c.PcuCreateWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePcuCreateResponse(rsp)
+}
+
+func (c *ClientWithResponses) PcuCreateWithResponse(ctx context.Context, body PcuCreateJSONRequestBody, reqEditors ...RequestEditorFn) (*PcuCreateResponse, error) {
+	rsp, err := c.PcuCreate(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePcuCreateResponse(rsp)
+}
+
+// PcuUpdateWithBodyWithResponse request with arbitrary body returning *PcuUpdateResponse
+func (c *ClientWithResponses) PcuUpdateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PcuUpdateResponse, error) {
+	rsp, err := c.PcuUpdateWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePcuUpdateResponse(rsp)
+}
+
+func (c *ClientWithResponses) PcuUpdateWithResponse(ctx context.Context, body PcuUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*PcuUpdateResponse, error) {
+	rsp, err := c.PcuUpdate(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePcuUpdateResponse(rsp)
+}
+
+// PcuGetWithBodyWithResponse request with arbitrary body returning *PcuGetResponse
+func (c *ClientWithResponses) PcuGetWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PcuGetResponse, error) {
+	rsp, err := c.PcuGetWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePcuGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) PcuGetWithResponse(ctx context.Context, body PcuGetJSONRequestBody, reqEditors ...RequestEditorFn) (*PcuGetResponse, error) {
+	rsp, err := c.PcuGet(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePcuGetResponse(rsp)
+}
+
+// PcuAssociationTransferWithBodyWithResponse request with arbitrary body returning *PcuAssociationTransferResponse
+func (c *ClientWithResponses) PcuAssociationTransferWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PcuAssociationTransferResponse, error) {
+	rsp, err := c.PcuAssociationTransferWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePcuAssociationTransferResponse(rsp)
+}
+
+func (c *ClientWithResponses) PcuAssociationTransferWithResponse(ctx context.Context, body PcuAssociationTransferJSONRequestBody, reqEditors ...RequestEditorFn) (*PcuAssociationTransferResponse, error) {
+	rsp, err := c.PcuAssociationTransfer(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePcuAssociationTransferResponse(rsp)
+}
+
+// PcuAssociationGetWithResponse request returning *PcuAssociationGetResponse
+func (c *ClientWithResponses) PcuAssociationGetWithResponse(ctx context.Context, pcuGroupUUID string, reqEditors ...RequestEditorFn) (*PcuAssociationGetResponse, error) {
+	rsp, err := c.PcuAssociationGet(ctx, pcuGroupUUID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePcuAssociationGetResponse(rsp)
+}
+
+// PcuAssociationDeleteWithResponse request returning *PcuAssociationDeleteResponse
+func (c *ClientWithResponses) PcuAssociationDeleteWithResponse(ctx context.Context, pcuGroupUUID string, datacenterUUID string, reqEditors ...RequestEditorFn) (*PcuAssociationDeleteResponse, error) {
+	rsp, err := c.PcuAssociationDelete(ctx, pcuGroupUUID, datacenterUUID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePcuAssociationDeleteResponse(rsp)
+}
+
+// PcuAssociationCreateWithResponse request returning *PcuAssociationCreateResponse
+func (c *ClientWithResponses) PcuAssociationCreateWithResponse(ctx context.Context, pcuGroupUUID string, datacenterUUID string, reqEditors ...RequestEditorFn) (*PcuAssociationCreateResponse, error) {
+	rsp, err := c.PcuAssociationCreate(ctx, pcuGroupUUID, datacenterUUID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePcuAssociationCreateResponse(rsp)
+}
+
+// PcuGroupParkWithResponse request returning *PcuGroupParkResponse
+func (c *ClientWithResponses) PcuGroupParkWithResponse(ctx context.Context, pcuGroupUUID string, reqEditors ...RequestEditorFn) (*PcuGroupParkResponse, error) {
+	rsp, err := c.PcuGroupPark(ctx, pcuGroupUUID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePcuGroupParkResponse(rsp)
+}
+
+// PcuGroupUnparkWithResponse request returning *PcuGroupUnparkResponse
+func (c *ClientWithResponses) PcuGroupUnparkWithResponse(ctx context.Context, pcuGroupUUID string, reqEditors ...RequestEditorFn) (*PcuGroupUnparkResponse, error) {
+	rsp, err := c.PcuGroupUnpark(ctx, pcuGroupUUID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePcuGroupUnparkResponse(rsp)
+}
+
+// PcuDeleteWithResponse request returning *PcuDeleteResponse
+func (c *ClientWithResponses) PcuDeleteWithResponse(ctx context.Context, pcuGroupUUID string, reqEditors ...RequestEditorFn) (*PcuDeleteResponse, error) {
+	rsp, err := c.PcuDelete(ctx, pcuGroupUUID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePcuDeleteResponse(rsp)
 }
 
 // DeleteVPCPeeringConnectionWithResponse request returning *DeleteVPCPeeringConnectionResponse
@@ -10808,6 +11956,357 @@ func ParseUpdateRolesForUserInOrganizationResponse(rsp *http.Response) (*UpdateR
 			return nil, err
 		}
 		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePcuCreateResponse parses an HTTP response from a PcuCreateWithResponse call
+func ParsePcuCreateResponse(rsp *http.Response) (*PcuCreateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PcuCreateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest []PCUGroup
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+		var dest ServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON5XX = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePcuUpdateResponse parses an HTTP response from a PcuUpdateWithResponse call
+func ParsePcuUpdateResponse(rsp *http.Response) (*PcuUpdateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PcuUpdateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+		var dest ServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON5XX = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePcuGetResponse parses an HTTP response from a PcuGetWithResponse call
+func ParsePcuGetResponse(rsp *http.Response) (*PcuGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PcuGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []PCUGroup
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+		var dest ServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON5XX = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePcuAssociationTransferResponse parses an HTTP response from a PcuAssociationTransferWithResponse call
+func ParsePcuAssociationTransferResponse(rsp *http.Response) (*PcuAssociationTransferResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PcuAssociationTransferResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+		var dest ServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON5XX = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePcuAssociationGetResponse parses an HTTP response from a PcuAssociationGetWithResponse call
+func ParsePcuAssociationGetResponse(rsp *http.Response) (*PcuAssociationGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PcuAssociationGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []PCUAssociation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+		var dest ServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON5XX = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePcuAssociationDeleteResponse parses an HTTP response from a PcuAssociationDeleteWithResponse call
+func ParsePcuAssociationDeleteResponse(rsp *http.Response) (*PcuAssociationDeleteResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PcuAssociationDeleteResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+		var dest ServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON5XX = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePcuAssociationCreateResponse parses an HTTP response from a PcuAssociationCreateWithResponse call
+func ParsePcuAssociationCreateResponse(rsp *http.Response) (*PcuAssociationCreateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PcuAssociationCreateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+		var dest ServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON5XX = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePcuGroupParkResponse parses an HTTP response from a PcuGroupParkWithResponse call
+func ParsePcuGroupParkResponse(rsp *http.Response) (*PcuGroupParkResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PcuGroupParkResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+		var dest ServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON5XX = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePcuGroupUnparkResponse parses an HTTP response from a PcuGroupUnparkWithResponse call
+func ParsePcuGroupUnparkResponse(rsp *http.Response) (*PcuGroupUnparkResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PcuGroupUnparkResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+		var dest ServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON5XX = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePcuDeleteResponse parses an HTTP response from a PcuDeleteWithResponse call
+func ParsePcuDeleteResponse(rsp *http.Response) (*PcuDeleteResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PcuDeleteResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 5:
+		var dest ServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON5XX = &dest
 
 	}
 

--- a/openapi/astra-devops-api.yaml
+++ b/openapi/astra-devops-api.yaml
@@ -2688,6 +2688,35 @@ components:
         - AWS
         - GCP
         - AZURE
+    InstanceType:
+      type: string
+      description: "Instance type for PCU groups"
+      enum:
+        - standard
+        - storageOptimized
+    ProvisionType:
+      type: string
+      description: "Provision type for PCU groups"
+      enum:
+        - shared
+        - dedicated
+    PCUGroupStatus:
+      type: string
+      description: "PCU Group lifecycle status"
+      enum:
+        - CREATED
+        - PLACING
+        - INITIALIZING
+        - PARKING
+        - PARKED
+        - UNPARKING
+        - ACTIVE
+    PCUAssociationStatus:
+      type: string
+      description: "PCU Association provisioning status"
+      enum:
+        - Created
+        - Accepted
     UserInvite:
       type: "object"
       description: "The userInvite model"
@@ -4521,21 +4550,15 @@ components:
             description: Title of the PCU group
             example: "some title"
           cloudProvider:
-            type: string
-            description: Cloud provider of the PCU group
-            example: [ "AWS", "GCP", "AZURE" ]
+            $ref: '#/components/schemas/CloudProvider'
           region:
             type: string
             description: Region of the PCU group
             example: "us-east-1"
           instanceType:
-            type: string
-            description: Instance type of the PCU group
-            example: "standard"
+            $ref: '#/components/schemas/InstanceType'
           provisionType:
-            type: string
-            description: Provision type of the PCU group
-            example: "shared"
+            $ref: '#/components/schemas/ProvisionType'
           min:
             type: integer
             description: Minimum shared hourly PCUs in the PCU group
@@ -4569,9 +4592,7 @@ components:
             description: User who updated the PCU group
             example: "user"
           status:
-            type: string
-            description: Status of the PCU Group
-            example: "INITIALIZING"
+            $ref: '#/components/schemas/PCUGroupStatus'
     PCUGroupCreateRequest:
         type: object
         description: PCU Group Create Request Model
@@ -4585,21 +4606,15 @@ components:
             description: Title of the PCU group
             example: "some title"
           cloudProvider:
-            type: string
-            description: Cloud provider of the PCU group
-            example: [ "AWS", "GCP", "AZURE" ]
+            $ref: '#/components/schemas/CloudProvider'
           region:
             type: string
             description: Region of the PCU group
             example: "us-east-1"
           instanceType:
-            type: string
-            description: Instance type of the PCU group
-            example: "standard"
+            $ref: '#/components/schemas/InstanceType'
           provisionType:
-            type: string
-            description: Provision type of the PCU group
-            example: "shared"
+            $ref: '#/components/schemas/ProvisionType'
           min:
             type: integer
             description: Minimum shared hourly PCUs in the PCU group
@@ -4629,13 +4644,9 @@ components:
             description: Title of the PCU group
             example: "some title"
           instanceType:
-            type: string
-            description: Instance type of the PCU group
-            example: "standard"
+            $ref: '#/components/schemas/InstanceType'
           provisionType:
-            type: string
-            description: Provision type of the PCU group
-            example: "shared"
+            $ref: '#/components/schemas/ProvisionType'
           min:
             type: integer
             description: Minimum shared hourly PCUs in the PCU group
@@ -4681,9 +4692,7 @@ components:
             description: PCU group this association belongs to
             example: '48de8fc3-b8ec-4ed2-8951-4aeaf4c9e626'
           provisioningStatus:
-            type: string
-            description: Provisioning status of the PCU association
-            example: 'Accepted'
+            $ref: '#/components/schemas/PCUAssociationStatus'
           createdAt:
             type: string
             description: Creation time of the PCU association

--- a/openapi/astra-devops-api.yaml
+++ b/openapi/astra-devops-api.yaml
@@ -44,6 +44,8 @@ tags:
     description: Create and view Customer Keys for your Astra DB organization
   - name: Enterprise Operations
     description: The DevOps APIs for your Astra organization
+  - name: PCU
+    description: The DevOps PCU (Provisioned Capacity Units) APIs for managing PCU groups and associations
 paths:
   /v2/authenticateServiceAccount:
     post:
@@ -2208,6 +2210,290 @@ paths:
           "$ref": "#/components/responses/NotFound"
         '500':
           "$ref": "#/components/responses/ServerError"
+  /v2/pcus/actions/get:
+    post:
+      tags:
+        - PCU
+      summary: Gets the PCU groups
+      description: Gets the PCU groups
+      operationId: pcuGet
+      requestBody:
+        description: PCU group UUIDs
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PCUGroupGetRequest'
+      responses:
+        '200':
+          description: Returns the PCU group
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PCUGroup'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+  /v2/pcus/{pcuGroupUUID}:
+    delete:
+      tags:
+        - PCU
+      summary: Deletes a PCU Group
+      description: Deletes a flexible capacity PCU group, based on the given PCU Group UUID.
+      operationId: pcuDelete
+      parameters:
+        - in: path
+          name: pcuGroupUUID
+          required: true
+          description: The PCU Group UUID to delete
+          schema:
+            type: string
+      responses:
+        '200':
+          description: "PCU Group deleted"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+  /v2/pcus:
+    post:
+      tags:
+        - PCU
+      summary: Creates a PCU group
+      description: Given PCU group information, creates a PCU group
+      operationId: pcuCreate
+      requestBody:
+        description: PCU group model.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              minItems: 1
+              maxItems: 1
+              items:
+                $ref: '#/components/schemas/PCUGroupCreateRequest'
+      responses:
+        '201':
+          description: Returns the created PCU groups
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PCUGroup'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+    put:
+      tags:
+        - PCU
+      summary: Updates one or more PCU groups
+      description: Given PCU group information, updates the PCU groups
+      operationId: pcuUpdate
+      requestBody:
+        description: PCU Group model.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              minItems: 1
+              maxItems: 1
+              items:
+                $ref: '#/components/schemas/PCUGroupUpdateRequest'
+      responses:
+        '200':
+          description: "PCU groups updated"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PCUGroup'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+  /v2/pcus/association/{pcuGroupUUID}:
+    get:
+      tags:
+        - PCU
+      summary: Gets a PCU group UUID returns all associated datacenters and their status
+      description: Given a PCU group UUID, returns all associated datacenters and their status
+      operationId: pcuAssociationGet
+      parameters:
+        - in: path
+          name: pcuGroupUUID
+          required: true
+          description: The PCU group UUID to get the associated datacenters and their status
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Returns the associated datacenters and their status
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PCUAssociation'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+  /v2/pcus/association/transfer:
+    post:
+      tags:
+        - PCU
+      summary: Transfers a PCU group association
+      description: Transfers a database, specified by datacenter ID, from one PCU group to another.
+      operationId: pcuAssociationTransfer
+      requestBody:
+        description: PCUAssociation Transfer Request.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PCUAssociationTransferRequest'
+      responses:
+        '202':
+          description: Successfully accepted the PCU Association Transfer request
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+  /v2/pcus/association/{pcuGroupUUID}/{datacenterUUID}:
+    post:
+      tags:
+        - PCU
+      summary: Creates a PCU group association
+      description: Given PCU group UUID and datacenter UUID, creates a PCU group association
+      operationId: pcuAssociationCreate
+      parameters:
+        - in: path
+          name: pcuGroupUUID
+          required: true
+          description: The PCU group UUID part of this association
+          schema:
+            type: string
+        - in: path
+          name: datacenterUUID
+          required: true
+          description: The datacenter UUID part of this association
+          schema:
+            type: string
+      responses:
+        '201':
+          description: Created PCU association
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+    delete:
+      tags:
+        - PCU
+      summary: Deletes a PCU group association
+      description: Given datacenter UUID and PCU group UUID, delete the association
+      operationId: pcuAssociationDelete
+      parameters:
+        - in: path
+          name: pcuGroupUUID
+          required: true
+          description: The PCU group UUID part of this association
+          schema:
+            type: string
+        - in: path
+          name: datacenterUUID
+          required: true
+          description: The datacenter UUID part of this association
+          schema:
+            type: string
+      responses:
+        '200':
+          description: "PCU association deleted"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+  /v2/pcus/park/{pcuGroupUUID}:
+    post:
+      tags:
+        - PCU
+      summary: Parks a PCU group
+      description: Parks a flexible capacity PCU group
+      operationId: pcuGroupPark
+      parameters:
+        - in: path
+          name: pcuGroupUUID
+          required: true
+          description: The PCU Group UUID to park
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successfully initialized the parking operation
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+  /v2/pcus/unpark/{pcuGroupUUID}:
+    post:
+      tags:
+        - PCU
+      summary: Unparks a PCU group
+      description: Unparks a flexible capacity PCU group
+      operationId: pcuGroupUnpark
+      parameters:
+        - in: path
+          name: pcuGroupUUID
+          required: true
+          description: The PCU Group UUID to unpark
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successfully initialized the unparking operation
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
   /v2/enterprises/organizations:
     post:
       tags:
@@ -4208,6 +4494,212 @@ components:
           type: string
           example: Active
           description: CDC config status
+    PCUGroupGetRequest:
+        type: object
+        description: PCU groups to get
+        properties:
+          pcuGroupUUIDs:
+            type: array
+            description: PCU group UIDs
+            items:
+              type: string
+              example: 1
+    PCUGroup:
+        type: object
+        description: PCU Group Model
+        properties:
+          uuid:
+            type: string
+            description: UUID of the PCU group
+            example: "9aaddbb5-4622-447c-9bc5-b036bb9d7ed8"
+          orgId:
+            type: string
+            description: Organization ID
+            example: "org-id"
+          title:
+            type: string
+            description: Title of the PCU group
+            example: "some title"
+          cloudProvider:
+            type: string
+            description: Cloud provider of the PCU group
+            example: [ "AWS", "GCP", "AZURE" ]
+          region:
+            type: string
+            description: Region of the PCU group
+            example: "us-east-1"
+          instanceType:
+            type: string
+            description: Instance type of the PCU group
+            example: "standard"
+          provisionType:
+            type: string
+            description: Provision type of the PCU group
+            example: "shared"
+          min:
+            type: integer
+            description: Minimum shared hourly PCUs in the PCU group
+            example: 1
+          max:
+            type: integer
+            description: Maximum shared hourly PCUs in the PCU group
+            example: 1
+          reserved:
+            type: integer
+            description: Absolute required PCUs in the PCU group
+            example: 1
+          description:
+            type: string
+            description: Description of the PCU group
+            example: "some description"
+          createdAt:
+            type: string
+            description: Creation time of the PCU group
+            example: "2021-06-01T12:00:00.000Z"
+          updatedAt:
+            type: string
+            description: Update time of the PCU group
+            example: "2021-06-01T12:00:00.000Z"
+          createdBy:
+            type: string
+            description: User who created the PCU group
+            example: "user"
+          updatedBy:
+            type: string
+            description: User who updated the PCU group
+            example: "user"
+          status:
+            type: string
+            description: Status of the PCU Group
+            example: "INITIALIZING"
+    PCUGroupCreateRequest:
+        type: object
+        description: PCU Group Create Request Model
+        properties:
+          orgID:
+            type: string
+            description: OrganizationID of the PCU group, ignored for authenticated users
+            example: "some-org"
+          title:
+            type: string
+            description: Title of the PCU group
+            example: "some title"
+          cloudProvider:
+            type: string
+            description: Cloud provider of the PCU group
+            example: [ "AWS", "GCP", "AZURE" ]
+          region:
+            type: string
+            description: Region of the PCU group
+            example: "us-east-1"
+          instanceType:
+            type: string
+            description: Instance type of the PCU group
+            example: "standard"
+          provisionType:
+            type: string
+            description: Provision type of the PCU group
+            example: "shared"
+          min:
+            type: integer
+            description: Minimum shared hourly PCUs in the PCU group
+            example: 1
+          max:
+            type: integer
+            description: Maximum shared hourly PCUs in the PCU group
+            example: 1
+          reserved:
+            type: integer
+            description: Absolute required PCUs in the PCU group
+            example: 1
+          description:
+            type: string
+            description: Description of the PCU group
+            example: "some-description"
+    PCUGroupUpdateRequest:
+        type: object
+        description: PCU Group Update Request Model
+        properties:
+          pcuGroupUUID:
+            type: string
+            description: UUID of the PCU group to update
+            example: "9aaddbb5-4622-447c-9bc5-b036bb9d7ed8"
+          title:
+            type: string
+            description: Title of the PCU group
+            example: "some title"
+          instanceType:
+            type: string
+            description: Instance type of the PCU group
+            example: "standard"
+          provisionType:
+            type: string
+            description: Provision type of the PCU group
+            example: "shared"
+          min:
+            type: integer
+            description: Minimum shared hourly PCUs in the PCU group
+            example: 1
+          max:
+            type: integer
+            description: Maximum shared hourly PCUs in the PCU group
+            example: 1
+          reserved:
+            type: integer
+            description: Absolute required PCUs in the PCU group
+            example: 1
+          description:
+            type: string
+            description: Description of the PCU group
+            example: "some-description"
+    PCUAssociationTransferRequest:
+      type: object
+      description: PCU association transfer
+      properties:
+        fromPCUGroupUUID:
+          type: string
+          description: The PCU Group UUID from which we want to move an association
+          example: '48de8fc3-b8ec-4ed2-8951-4aeaf4c9e626'
+        toPCUGroupUUID:
+          type: string
+          description: The PCU Group UUID to which we want to move the association
+          example: '48de8fc3-b8ec-4ed2-8951-4aeaf4c9e626'
+        datacenterUUID:
+          type: string
+          description: The Datacenter UUID that is part of the fromPCUGroupUUID which we want to move to the toPCUGroupUUID
+          example: '48de8fc3-b8ec-4ed2-8951-4aeaf4c9e626-1'
+    PCUAssociation:
+        type: object
+        description: PCUAssociation information
+        properties:
+          datacenterUUID:
+            type: string
+            description: Datacenter UUID of the PCU association
+            example: '48de8fc3-b8ec-4ed2-8951-4aeaf4c9e626'
+          pcuGroupUUID:
+            type: string
+            description: PCU group this association belongs to
+            example: '48de8fc3-b8ec-4ed2-8951-4aeaf4c9e626'
+          provisioningStatus:
+            type: string
+            description: Provisioning status of the PCU association
+            example: 'Accepted'
+          createdAt:
+            type: string
+            description: Creation time of the PCU association
+            example: "2021-06-01T12:00:00.000Z"
+          updatedAt:
+            type: string
+            description: Update time of the PCU association
+            example: "2021-06-01T12:00:00.000Z"
+          createdBy:
+            type: string
+            description: User who created the PCU association
+            example: "user"
+          updatedBy:
+            type: string
+            description: User who updated the PCU association
+            example: "user"
 
   responses:
     # 200

--- a/openapi/astra-devops-api.yaml
+++ b/openapi/astra-devops-api.yaml
@@ -2239,8 +2239,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-        '5XX':
-          $ref: '#/components/responses/ServerError'
+        '500':
+          "$ref": "#/components/responses/ServerError"
   /v2/pcus/{pcuGroupUUID}:
     delete:
       tags:
@@ -2264,8 +2264,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-        '5XX':
-          $ref: '#/components/responses/ServerError'
+        '500':
+          "$ref": "#/components/responses/ServerError"
   /v2/pcus:
     post:
       tags:
@@ -2297,7 +2297,7 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/Forbidden'
-        '5XX':
+        '500':
           $ref: '#/components/responses/ServerError'
     put:
       tags:
@@ -2331,7 +2331,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-        '5XX':
+        '500':
           $ref: '#/components/responses/ServerError'
   /v2/pcus/association/{pcuGroupUUID}:
     get:
@@ -2362,7 +2362,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-        '5XX':
+        '500':
           $ref: '#/components/responses/ServerError'
   /v2/pcus/association/transfer:
     post:
@@ -2385,7 +2385,7 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/Forbidden'
-        '5XX':
+        '500':
           $ref: '#/components/responses/ServerError'
   /v2/pcus/association/{pcuGroupUUID}/{datacenterUUID}:
     post:
@@ -2416,7 +2416,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-        '5XX':
+        '500':
           $ref: '#/components/responses/ServerError'
     delete:
       tags:
@@ -2446,7 +2446,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-        '5XX':
+        '500':
           $ref: '#/components/responses/ServerError'
   /v2/pcus/park/{pcuGroupUUID}:
     post:
@@ -2469,7 +2469,7 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/Forbidden'
-        '5XX':
+        '500':
           $ref: '#/components/responses/ServerError'
   /v2/pcus/unpark/{pcuGroupUUID}:
     post:
@@ -2492,7 +2492,7 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/Forbidden'
-        '5XX':
+        '500':
           $ref: '#/components/responses/ServerError'
   /v2/enterprises/organizations:
     post:

--- a/openapi/astra-devops-api.yaml
+++ b/openapi/astra-devops-api.yaml
@@ -4615,6 +4615,15 @@ components:
     PCUGroupCreateRequest:
         type: object
         description: PCU Group Create Request Model
+        required:
+          - cloudProvider
+          - instanceType
+          - provisionType
+          - reserved
+          - min
+          - max
+          - region
+          - title
         properties:
           orgID:
             type: string
@@ -4653,6 +4662,16 @@ components:
     PCUGroupUpdateRequest:
         type: object
         description: PCU Group Update Request Model
+        required:
+          - pcuGroupUUID
+          - cloudProvider
+          - instanceType
+          - provisionType
+          - reserved
+          - min
+          - max
+          - region
+          - title
         properties:
           pcuGroupUUID:
             type: string

--- a/openapi/astra-devops-api.yaml
+++ b/openapi/astra-devops-api.yaml
@@ -2695,14 +2695,17 @@ components:
         - standard
         - storageOptimized
       x-enum-varnames:
-        - InstanceTypeStandard
-        - InstanceTypeStorageOptimized
+        - PcuInstanceTypeStandard
+        - PcuInstanceTypeStorageOptimized
     ProvisionType:
       type: string
       description: "Provision type for PCU groups"
       enum:
         - shared
         - dedicated
+      x-enum-varnames:
+        - PcuProvisionTypeShared
+        - PcuProvisionTypeDedicated
     PCUGroupStatus:
       type: string
       description: "PCU Group lifecycle status"

--- a/openapi/astra-devops-api.yaml
+++ b/openapi/astra-devops-api.yaml
@@ -2694,6 +2694,9 @@ components:
       enum:
         - standard
         - storageOptimized
+      x-enum-varnames:
+        - InstanceTypeStandard
+        - InstanceTypeStorageOptimized
     ProvisionType:
       type: string
       description: "Provision type for PCU groups"
@@ -2711,12 +2714,23 @@ components:
         - PARKED
         - UNPARKING
         - ACTIVE
+      x-enum-varnames:
+        - PCUGroupStatusCREATED
+        - PCUGroupStatusPLACING
+        - PCUGroupStatusINITIALIZING
+        - PCUGroupStatusPARKING
+        - PCUGroupStatusPARKED
+        - PCUGroupStatusUNPARKING
+        - PCUGroupStatusACTIVE
     PCUAssociationStatus:
       type: string
       description: "PCU Association provisioning status"
       enum:
         - Created
         - Accepted
+      x-enum-varnames:
+        - PCUAssociationStatusCreated
+        - PCUAssociationStatusAccepted
     UserInvite:
       type: "object"
       description: "The userInvite model"
@@ -2802,6 +2816,7 @@ components:
       type: string
       enum: [ACTIVE, PENDING, PREPARING, PREPARED, INITIALIZING, PARKED, PARKING, UNPARKING, TERMINATED, TERMINATING, RESIZING, ERROR, MAINTENANCE, SUSPENDED, UNKNOWN]
       example: ACTIVE
+      x-enum-varnames: [ACTIVE, PENDING, PREPARING, PREPARED, INITIALIZING, PARKED, PARKING, UNPARKING, TERMINATED, TERMINATING, RESIZING, ERROR, MAINTENANCE, SUSPENDED, UNKNOWN]
     Database:
       type: object
       description: Database contains the key information about a database
@@ -2915,6 +2930,7 @@ components:
           type: string
           example: standard
           enum: [standard, premium, premium_plus]
+          x-enum-varnames: [Standard, Premium, PremiumPlus]
         capacityUnits:
           type: integer
           example: 1
@@ -3594,6 +3610,9 @@ components:
           description: The current status of the connection
           example: Accepted
           enum:
+            - Accepted
+            - Rejected
+          x-enum-varnames:
             - Accepted
             - Rejected
         createdDateTime:

--- a/openapi/astra-devops-api.yaml
+++ b/openapi/astra-devops-api.yaml
@@ -2688,15 +2688,6 @@ components:
         - AWS
         - GCP
         - AZURE
-    InstanceType:
-      type: string
-      description: "Instance type for PCU groups"
-      enum:
-        - standard
-        - storageOptimized
-      x-enum-varnames:
-        - PcuInstanceTypeStandard
-        - PcuInstanceTypeStorageOptimized
     ProvisionType:
       type: string
       description: "Provision type for PCU groups"
@@ -4578,7 +4569,9 @@ components:
             description: Region of the PCU group
             example: "us-east-1"
           instanceType:
-            $ref: '#/components/schemas/InstanceType'
+            type: string
+            description: "Instance type for PCU groups"
+            example: "standard"
           provisionType:
             $ref: '#/components/schemas/ProvisionType'
           min:
@@ -4643,7 +4636,9 @@ components:
             description: Region of the PCU group
             example: "us-east-1"
           instanceType:
-            $ref: '#/components/schemas/InstanceType'
+            type: string
+            description: "Instance type for PCU groups"
+            example: "standard"
           provisionType:
             $ref: '#/components/schemas/ProvisionType'
           min:
@@ -4685,7 +4680,9 @@ components:
             description: Title of the PCU group
             example: "some title"
           instanceType:
-            $ref: '#/components/schemas/InstanceType'
+            type: string
+            description: "Instance type for PCU groups"
+            example: "standard"
           provisionType:
             $ref: '#/components/schemas/ProvisionType'
           min:


### PR DESCRIPTION
Add in all PCU-related endpoints to the go client

**Example: Create a PCU Group**
```go
ctx := context.Background()
client, _ := astra.NewClientWithResponses("https://api.astra.datastax.com",
    astra.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
        req.Header.Set("Authorization", "Bearer "+token)
        return nil
    }))

resp, _ := client.PcuCreateWithResponse(ctx, []astra.PCUGroupCreateRequest{{
    Title:         "Production PCU Group",
    Region:        "us-east-1",
    Reserved:      100,
    Min:           50,
    Max:           200,
    InstanceType:  "standard",
    ProvisionType: provisionTypePtr(astra.ProvisionTypeServerless),
}})

if resp.JSON201 != nil {
    pcuGroupUUID := (*resp.JSON201)[0].Uuid
    fmt.Printf("Created PCU Group: %s\n", *pcuGroupUUID)
}
```

**Example: Get associations and add a new one**
```go
resp, _ := client.PcuAssociationGetWithResponse(ctx, "pcu-group-uuid")

if resp.JSON200 != nil {
    for _, assoc := range *resp.JSON200 {
        fmt.Printf("Datacenter: %s, Status: %s\n",
            *assoc.DatacenterUUID, *assoc.ProvisioningStatus)
    }
}

resp, _ := client.PcuAssociationCreateWithResponse(ctx,
    "pcu-group-uuid",
    "datacenter-uuid")

if resp.StatusCode() == 201 {
    fmt.Println("Database associated with PCU group")
}
```

